### PR TITLE
Update Alias Return Type

### DIFF
--- a/src/main/kotlin/me/honkling/pocket/Aliases.kt
+++ b/src/main/kotlin/me/honkling/pocket/Aliases.kt
@@ -3,5 +3,5 @@ package me.honkling.pocket
 import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.event.inventory.InventoryCloseEvent
 
-typealias ClickHandler = (InventoryClickEvent) -> Any?
-typealias CloseHandler = (CancellableInventoryCloseEvent) -> Any?
+typealias ClickHandler = (InventoryClickEvent) -> Unit
+typealias CloseHandler = (CancellableInventoryCloseEvent) -> Unit


### PR DESCRIPTION
Having the handlers return `Any?` is unnecessary when the correct operation should be a `Unit`. 